### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -82,11 +82,11 @@ fi
 
 # Remove files for upgrade compatibilty from previous versions of Friendica 
 if [ -f $final_path/.htconfig.php ]; then
-	rm "$final_path/.htconfig.php"
+	ynh_secure_remove "$final_path/.htconfig.php"
 fi
 
 if [ -f $final_path/.htconfig.php ]; then
-	rm "$final_path/config/local.ini.php"
+	ynh_secure_remove "$final_path/config/local.ini.php"
 fi
 
 
@@ -121,7 +121,7 @@ ynh_replace_string --match_string="OPEN"  --replace_string="CLOSED" --target_fil
 
 
 #Copy Addons
-rm -Rf "$final_path/addon"
+ynh_secure_remove "$final_path/addon"
 ynh_setup_source --dest_dir="$final_path/addon" --source_id="addons"
 
 # 3 - some extra folders


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 