### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "email": "anmol@datamol.org"
     },
     "requirements": {
-		"yunohost": ">= 4.0.0"
+		"yunohost": ">= 4.1.0"
     },
     "previous_maintainers": {
         "name": "aymhce",


### PR DESCRIPTION
    ! Using official helper ynh_legacy_permissions_delete_all implies requiring at least version 4.1, but manifest only requires 4.0.0 
    ! Using official helper ynh_legacy_permissions_exists implies requiring at least version 4.1, but manifest only requires 4.0.0 