### PR TITLE
Use correct commit hashes for 22.10 and addons.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Social Communication Server",
         "fr": "Serveur de Communication Social"
     },
-    "version": "2022.10~ynh1",
+    "version": "2022.10~ynh2",
     "url": "http://friendi.ca",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,9 +5,9 @@
 #=================================================
 
 # commit hashes
-# 2022.06
-version_commit="ca3dcdad04a69b91f67c0e7567d391a48d944bf9"
-addons_version_commit="e0ad3e0fc778ce202021fb5e2dd3cc2a94496b8c"
+# 2022.10
+version_commit="7109d2a6a8924e8cec7735017fdc00bb1af38b8c"
+addons_version_commit="408a62a9a16d2613ab37bc9e5dabf5fd63b36b73"
 
 # dependencies used by the app
 YNH_PHP_VERSION="7.4"


### PR DESCRIPTION
## Problem

- The wrong commit hashes appear to have been used for Friendica 22.10 and its addons.

## Solution

- Use the correct hashes.

## PR Status

- [X ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
