### PR TITLE
Updated to the proper 2022.12 stable commits

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # commit hashes
 # 2022.12
-version_commit="8b3a9fc58a969a3d9202f6858d5228f3a28be1ef"
+version_commit="eeadc00e83d8bc7144b0edf74c0fe851ef8636a6"
 addons_version_commit="f922d69310f5229d2e9404f396d66453b2d19d90"
 
 # dependencies used by the app


### PR DESCRIPTION
## Problem

The latest commit pushed to the main ynh branch was again a dev commit and this will again break all friendica installs.

## Solution

Add the proper commits that come from the stable branch, this one https://github.com/friendica/friendica/commits/stable

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
