### PR TITLE
Remove dependency on direct database calls during install

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -12,7 +12,7 @@ addons_version_commit="f922d69310f5229d2e9404f396d66453b2d19d90"
 # dependencies used by the app
 YNH_PHP_VERSION="7.4"
 
-pkg_dependencies="php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-gd"
+pkg_dependencies="php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-cli php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-imagick php${YNH_PHP_VERSION}-xml php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-mysql php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-gmp"
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -119,12 +119,7 @@ ynh_add_nginx_config
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
-ynh_script_progression --message="Adding a configuration file..." --weight=1
-
-ynh_add_config --template="../conf/local-sample.config.php" --destination="$final_path/config/local.config.php"
-
-# init db
-ynh_mysql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" < "$final_path/database.sql"
+ynh_script_progression --message="Adding the LDAP Auth addon configuration file..." --weight=1
 
 # LDAP addon config
 ynh_add_config --template="../conf/addon.config.php" --destination="$final_path/config/addon.config.php"
@@ -145,7 +140,7 @@ chmod -R 775 "$final_path/view/smarty3"
 #=================================================
 # SETUP A CRON
 #=================================================
-ynh_script_progression --message="Setuping a cron job..." --weight=1
+ynh_script_progression --message="Setting up the cron job..." --weight=1
 
 ynh_add_config --template="../conf/cron" --destination="/etc/cron.d/$app"
 chown root: "/etc/cron.d/$app"
@@ -154,14 +149,20 @@ chmod 644 "/etc/cron.d/$app"
 #=================================================
 # INSTALL FRIENDICA
 #=================================================
+ynh_script_progression --message="Install Friendica..." --weight=1
 
-# Run composer
 pushd "$final_path"
- 	ynh_exec_as "$app" php$phpversion bin/composer.phar install --no-dev --quiet
-	ynh_exec_as "$app" bin/console config system addon ldapauth
-popd
+	# Import Composer dependencies
+	ynh_exec_as "$app" php$phpversion bin/composer.phar install --no-dev --quiet
 
-ynh_mysql_connect_as --user="$db_user" --password="$db_pwd" --database="$db_name" <<< "INSERT INTO addon (id, name, version, installed, hidden, timestamp, plugin_admin) VALUES (NULL, 'ldapauth', '', '1', '0', UNIX_TIMESTAMP(), '0');"
+	# Install application
+	ynh_exec_as "$app" php$phpversion bin/console.php autoinstall\
+		--dbhost "$db_host" --dbdata "$db_name" --dbuser "$db_user" --dbpass "$db_pwd"\
+		--admin "$email" --tz "$timezone" --lang "$language" --url "https://$domain$path_url"
+
+	# Enable LDAP Auth addon
+	ynh_exec_as "$app" php$phpversion bin/console.php addon enable ldapauth
+popd
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -157,7 +157,7 @@ pushd "$final_path"
 
 	# Install application
 	ynh_exec_as "$app" php$phpversion bin/console.php autoinstall\
-		--dbhost "$db_host" --dbdata "$db_name" --dbuser "$db_user" --dbpass "$db_pwd"\
+		--dbhost "localhost" --dbdata "$db_name" --dbuser "$db_user" --dbpass "$db_pwd"\
 		--admin "$email" --tz "$timezone" --lang "$language" --url "https://$domain$path_url"
 
 	# Enable LDAP Auth addon


### PR DESCRIPTION
- Use `console autoinstall` command instead which creates the local.config.php file and initializes the database
- Use `console addon enable` to activate the LDAP Auth addon

## Problem

- Direct SQL call fails during install script: https://github.com/YunoHost-Apps/friendica_ynh/pull/93#issuecomment-1586179776

## Solution

- Remove dependency on direct database calls during install by using the Friendica `console` command to first install the application and then enabled the LDAP Auth addon.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
