### PR TITLE
Enable the Maintenance mode for the Friendica backup script

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -63,6 +63,10 @@ ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 # Backup cron job
 ynh_backup --src_path="/etc/cron.d/$app"
 
+# Put Friendica in maintenance mode
+ynh_print_info --message="Enabling the maintenance mode for Friendica"
+/var/www/friendica/bin/console maintenance 1
+
 #=================================================
 # BACKUP THE MYSQL DATABASE
 #=================================================
@@ -70,8 +74,13 @@ ynh_print_info --message="Backing up the MySQL database..."
 
 ynh_mysql_dump_db --database="$db_name" > db.sql
 
+# Disable the maintenance mode for Friendica
+ynh_print_info --message="Disabling the maintenance mode for Friendica"
+/var/www/friendica/bin/console maintenance 0
+
 #=================================================
 # END OF SCRIPT
 #=================================================
+
 
 ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)."


### PR DESCRIPTION
This is done to avoid errors with the database and be able to properly back it up. Else it will fail if you Friendica is an active instance and in the time that it takes to create a backup new entries will be added to the database. I tested it it works.
