### PR TITLE
Use console.php for entering/exiting maintenance mode.

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -15,7 +15,9 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_print_info --message="Declaring files to be backed up..."
 
-(cd $install_dir && ynh_exec_as "$app" php$phpversion bin/console maintenance 1)
+(cd $install_dir && ynh_exec_as "$app" php$phpversion bin/console.php maintenance 1)
+
+trap "(cd $install_dir && ynh_exec_as "$app" php$phpversion bin/console.php maintenance 0)" EXIT
 
 #=================================================
 # BACKUP THE APP MAIN DIR
@@ -60,8 +62,6 @@ ynh_backup --src_path="/etc/cron.d/$app"
 ynh_print_info --message="Backing up the MySQL database..."
 
 ynh_mysql_dump_db --database="$db_name" > db.sql
-
-(cd $install_dir && ynh_exec_as "$app" php$phpversion bin/console maintenance 0)
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -57,6 +57,13 @@ ynh_systemd_action --service_name=php$phpversion-fpm --action=reload
 
 ynh_systemd_action --service_name=nginx --action=reload
 
+#==============
+# FINALIZATION
+#==============
+
+# exit maintenance mode since the app was backed up while in maintenance mode
+(cd $install_dir && ynh_exec_as "$app" php$phpversion bin/console.php maintenance 0)
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -65,7 +65,7 @@ ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-error.log" --failreg
 # Run Composer
 pushd "$install_dir"
   ynh_exec_as "$app" php$phpversion bin/composer.phar install --no-dev --quiet
- 	ynh_exec_as "$app" php$phpversion bin/console dbstructure update
+ 	ynh_exec_as "$app" php$phpversion bin/console.php dbstructure update
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

- Backup script does not enter maintenance mode as per #111 

## Solution

- `bin/console` is a shell script, `bin/console.php` is a thing that needs to be run with PHP interpreter.
- if backup fails maintenance mode is not disabled - use `trap` to deal with it.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
