### PR TITLE
Bump the version to upgrade from for the test run with ynh unstable

### DIFF
--- a/tests.toml
+++ b/tests.toml
@@ -10,4 +10,4 @@ exclude = [ "install.private" ]
 # Commits to test upgrade from
 # -------------------------------
 
-test_upgrade_from.dc7cd3eabe212708375c0dcd4ee994a1373a8122.name = "Upgrade from 2023.01~ynh1"
+test_upgrade_from.a93169d04583ff13ba7d29aa4962477fb7e3b468.name = "Upgrade from 2023.12~ynh3"


### PR DESCRIPTION
## Problem

- Seems like the yunohost unstable, bookworm does not work good with the currently set 2023.01~ynh1 version commit to test the upgrade from.

## Solution

- A proposal is to bump the version to upgrade from to the latest used in main branch now.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
