### PR TITLE
Give permission to webserver to write friendica log.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -38,6 +38,10 @@ chmod -R 775 "$install_dir/view/smarty3"
 chmod -R o-rwx "$install_dir"
 chown -R "$app:www-data" "$install_dir"
 
+mkdir -p "/var/log/$app"
+chmod 770 "/var/log/$app"
+chown "$app:www-data" "/var/log/$app"
+
 ynh_add_config --template="local-sample.config.php" --destination="$install_dir/config/temp.config.php"
 
 #=================================================


### PR DESCRIPTION
Fixes Issue 161.

## Problem

- Enabling logging with the default log path doesn't work, because the server doesn't have permissions to write to that directory.

## Solution

- Abuse the group permission, so that the daemon has permission to write as a user, and the webserver has permission to write as a group.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
