### PR TITLE
add `php8.2-ldap` to fix login and `php8.2-imap` to enable user email/mailbox setup

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -70,7 +70,7 @@ main.allowed = [ "visitors", "all_users" ]
 main.protected = true
 
 [resources.apt]
-packages = "mariadb-server, php8.2-curl, php8.2-mbstring, php8.2-imagick, php8.2-xml, php8.2-zip, php8.2-mysql, php8.2-gd, php8.2-gmp, php8.2-intl"
+packages = "mariadb-server, php8.2-curl, php8.2-mbstring, php8.2-imagick, php8.2-xml, php8.2-zip, php8.2-mysql, php8.2-gd, php8.2-gmp, php8.2-intl, php8.2-ldap, php8.2-imap"
 
 [resources.database]
 type = "mysql"


### PR DESCRIPTION
## Problem

- *after fresh install, could not login with ldap-linked account(s)*
- *email/mailbox setup not enabled/available in webUI*

## Solution

- *add php8.2-ldap apt package*
- *add php8.2-imap apt package*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
