### PR TITLE
Adjust FastCGI buffer settings in nginx config

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -34,6 +34,9 @@ location __PATH__/ {
     try_files $uri =404;
     fastcgi_pass unix:/var/run/php/php__PHP_VERSION__-fpm-__APP__.sock;
     include fastcgi_params_with_auth;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+    fastcgi_busy_buffers_size 64k;
   }
 
   # deny access to all dot files


### PR DESCRIPTION
Increase FastCGI buffer sizes for PHP processing.

## Problem

- *Description of why you made this PR*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
