### PR TITLE
upgrade: add maintenance mode

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -3,6 +3,13 @@
 source /usr/share/yunohost/helpers
 
 #=================================================
+# MAINTENANCE MODE
+#=================================================
+(cd "$install_dir" && ynh_exec_as_app "php$php_version" bin/console.php maintenance 1)
+
+trap '(cd $install_dir && ynh_exec_as_app php$php_version bin/console.php maintenance 0)' EXIT
+
+#=================================================
 # STOP SYSTEMD SERVICE
 #=================================================
 ynh_script_progression "Stopping $app's systemd service..."


### PR DESCRIPTION
## Problem

- line `ynh_safe_rm "$install_dir/view/smarty3/compiled"` in upgrade script fails on some instances (#185)
- unable to reproduce issue, perhaps for lack of a busy enough instance

## Solution
- add 'enable+disable maintenance mode' to upgrade script

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested for general upgrade success
- [x] Needs to be tested on an instance that experiences this mode of failure -- thanks @tio-trom!