### PR TITLE
block public direct sql file access in $install_dir

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -25,7 +25,7 @@ location __PATH__/ {
   include mime.types;
 
   # block these file types
-  location ~* \.(tpl|md|tgz|log|out)$ {
+  location ~* \.(tpl|md|tgz|log|out|sql)$ {
     deny all;
   }
 


### PR DESCRIPTION
## Problem

- 2026.05 included `database.sql` file to update database; contains no identifying info, but was left in $install_dir, 0640, friendica:www-data
- vulnerability scanners find and flag this

## Solution

- add sql to filetyle deny block in `nginx.conf`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)